### PR TITLE
Let Carthage handle building / archiving.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     macos:
       xcode: "9.1.0"
-
+    
     steps:
       - checkout
       #Currently commented out due to a gem install error.
@@ -31,6 +31,11 @@ jobs:
       #     key: v1-gems-{{ checksum "Gemfile.lock" }}
       #     paths:
       #       - vendor/bundle
+      - run:
+          name: Install carthage
+          command: |
+            brew update
+            brew outdated carthage || brew upgrade carthage
       - run:
           name: Build Frameworks
           command: sh build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,5 @@
 rm -rf output
 mkdir output
 
-
-sh build-umbrella-framework.sh HyperionCore
-sh build-umbrella-framework.sh SlowAnimations
-sh build-umbrella-framework.sh Measurements
-sh build-umbrella-framework.sh AttributesInspector
+carthage build --no-skip-current --verbose
+carthage archive --output output/Hyperion.framework.zip


### PR DESCRIPTION
Currently cached released builds for carthage fail because of incomplete bitcode. This fixes the build so that carthage will take care of building and archiving all the frameworks for it to cache.